### PR TITLE
Tests Exercising Governor Alpha After Upgrade Proposal

### DIFF
--- a/test/GitcoinGovernor.t.sol
+++ b/test/GitcoinGovernor.t.sol
@@ -66,7 +66,7 @@ contract GitcoinGovernorProposalTestHelper is GitcoinGovernorTestHelper {
   uint8 constant EXECUTED = 7;
 
   function setUp() public virtual override {
-    super.setUp();
+    GitcoinGovernorTestHelper.setUp();
 
     initialProposalCount = governorAlpha.proposalCount();
 
@@ -249,7 +249,7 @@ contract GitcoinGovernorAlphaPostProposalTest is GitcoinGovernorProposalTestHelp
   IERC20 radToken = IERC20(RAD_ADDRESS);
 
   function setUp() public override {
-    super.setUp();
+    GitcoinGovernorProposalTestHelper.setUp();
     usdcToken = IERC20(USDC_ADDRESS);
     radToken = IERC20(RAD_ADDRESS);
   }


### PR DESCRIPTION
This PR addresses a small part of what's remaining in #5. In the spirit of more manageable reviews, I'm opening it for review while continuing to work through the rest of the testing for that issue.

In particular, this PR includes tests for Governor *Alpha* after the upgrade proposal. Two tests demonstrate Governor Alpha can still send various tokens the timelock owns after the upgrade proposal is *defeated*. A third test demonstrates Governor Alpha can *not* queue a proposal to send tokens after the upgrade succeeds.

Open to opinions on whether the tests should be broken up across multiple files. I almost split them up but opted to keep it in one big file for now.