### PR TITLE
ci/remove manual cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 
 env:
   FOUNDRY_PROFILE: ci
+  DEPLOYER_PRIVATE_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
+  MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
+  PROPOSER_PRIVATE_KEY: ${{ secrets.PROPOSER_PRIVATE_KEY }}
 
 jobs:
   build:
@@ -28,10 +31,6 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    env:
-      DEPLOYER_PRIVATE_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
-      MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
-      PROPOSER_PRIVATE_KEY: ${{ secrets.PROPOSER_PRIVATE_KEY }}
     steps:
       - uses: actions/checkout@v3
 
@@ -51,10 +50,6 @@ jobs:
         run: forge test
 
   coverage:
-    env:
-      DEPLOYER_PRIVATE_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
-      MAINNET_RPC_URL: ${{ secrets.MAINNET_RPC_URL }}
-      PROPOSER_PRIVATE_KEY: ${{ secrets.PROPOSER_PRIVATE_KEY }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,6 @@ jobs:
         with:
           version: nightly
 
-      - name: Cache fork requests
-        uses: actions/cache@v3
-        with:
-          path: ~/.foundry/cache
-          key: ${{ runner.os }}-foundry-network-fork-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-foundry-network-fork-
-
       # https://twitter.com/PaulRBerg/status/1611116650664796166
       - name: Generate fuzz seed with 1 week TTL
         run: >
@@ -71,14 +63,6 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
-
-      - name: Cache fork requests
-        uses: actions/cache@v3
-        with:
-          path: ~/.foundry/cache
-          key: ${{ runner.os }}-foundry-network-fork-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-foundry-network-fork-
 
       # https://twitter.com/PaulRBerg/status/1611116650664796166
       - name: Recycle the fuzz seed from the test run


### PR DESCRIPTION
- Removes the manual cache since foundry-toolchain was fixed upstream
    - [First run](https://github.com/gitcoinco/Alpha-Governor-Upgrade/actions/runs/3944681877/jobs/6750849084), tests took 7 mins
    - [Second run](https://github.com/gitcoinco/Alpha-Governor-Upgrade/actions/runs/3944681877), tests took ~4.5 mins, still longer than expected, so don't merge yet
    - [Third run](https://github.com/gitcoinco/Alpha-Governor-Upgrade/actions/runs/3944782488) took about the same, ran it in case I ran the second one too quickly after the first 
- Dedupes env var declarations