### PR TITLE
Updates Test Suite To Execute Using Live Onchain Proposal Data

### DIFF
--- a/script/Propose.s.sol
+++ b/script/Propose.s.sol
@@ -10,7 +10,7 @@ import {ICompoundTimelock} from
 contract ProposeScript is Script {
   IGovernorAlpha constant GOVERNOR_ALPHA =
     IGovernorAlpha(0xDbD27635A534A3d3169Ef0498beB56Fb9c937489);
-  address constant PROPOSER = 0xc2E2B715d9e302947Ec7e312fd2384b5a1296099; // kbw.eth
+  address PROPOSER = 0xc2E2B715d9e302947Ec7e312fd2384b5a1296099; // kbw.eth
 
   function propose(GitcoinGovernor _newGovernor) internal returns (uint256 _proposalId) {
     address[] memory _targets = new address[](2);
@@ -31,6 +31,13 @@ contract ProposeScript is Script {
     return GOVERNOR_ALPHA.propose(
       _targets, _values, _signatures, _calldatas, "Upgrade to Governor Bravo"
     );
+  }
+
+  /// @dev Used only in the context of testing in order to allow an alternate address to be the
+  /// proposer. This is needed when testing with live proposal data, because the Governor only
+  /// allows each proposer to have one live proposal at a time.
+  function overrideProposerForTests(address _testProposer) external {
+    PROPOSER = _testProposer;
   }
 
   /// @dev After the new Governor is deployed on mainnet, this can move from a parameter to a const

--- a/script/Propose.s.sol
+++ b/script/Propose.s.sol
@@ -33,13 +33,6 @@ contract ProposeScript is Script {
     );
   }
 
-  /// @dev Used only in the context of testing in order to allow an alternate address to be the
-  /// proposer. This is needed when testing with live proposal data, because the Governor only
-  /// allows each proposer to have one live proposal at a time.
-  function overrideProposerForTests(address _testProposer) external {
-    PROPOSER = _testProposer;
-  }
-
   /// @dev After the new Governor is deployed on mainnet, this can move from a parameter to a const
   function run(GitcoinGovernor _newGovernor) public returns (uint256 _proposalId) {
     // The expectation is the key loaded here corresponds to the address of the `proposer` above.

--- a/test/GitcoinGovernor.t.sol
+++ b/test/GitcoinGovernor.t.sol
@@ -336,7 +336,7 @@ abstract contract AlphaGovernorPostProposalTest is ProposalTestHelper {
     bool isGovernorAlphaAdmin
   ) internal {
     // Submit the new proposal
-    vm.prank(0x4Be88f63f919324210ea3A2cCAD4ff0734425F91);
+    vm.prank(PROPOSER);
     uint256 _newProposalId =
       governorAlpha.propose(_targets, _values, _signatures, _calldatas, "Proposal for old Governor");
 

--- a/test/GitcoinGovernor.t.sol
+++ b/test/GitcoinGovernor.t.sol
@@ -9,7 +9,7 @@ import {GitcoinGovernor, ICompoundTimelock} from "src/GitcoinGovernor.sol";
 import {DeployInput, DeployScript} from "script/Deploy.s.sol";
 import {IGovernorAlpha} from "src/interfaces/IGovernorAlpha.sol";
 import {IGTC} from "src/interfaces/IGTC.sol";
-import {ProposeScript} from "script/Propose.s.sol";
+import {TestableProposeScript} from "./TestableProposeScript.sol";
 
 abstract contract GitcoinGovernorTestHelper is Test, DeployInput {
   using FixedPointMathLib for uint256;
@@ -124,7 +124,7 @@ abstract contract ProposalTestHelper is GitcoinGovernorTestHelper {
       initialProposalCount = governorAlpha.proposalCount() - 1;
     } else {
       initialProposalCount = governorAlpha.proposalCount();
-      ProposeScript _proposeScript = new ProposeScript();
+      TestableProposeScript _proposeScript = new TestableProposeScript();
       // We override the deployer to use kevinolsen.eth, because in this context, kbw.eth already
       // has a live proposal
       _proposeScript.overrideProposerForTests(0x4Be88f63f919324210ea3A2cCAD4ff0734425F91);

--- a/test/GitcoinGovernor.t.sol
+++ b/test/GitcoinGovernor.t.sol
@@ -57,7 +57,7 @@ abstract contract GitcoinGovernorTestHelper is Test, DeployInput {
     }
 
     if (_useDeployedGovernorBravo()) {
-      // The GitcoinGovernor contract was deployed to mainnet on April 7th 2023
+      // The GitcoinGovernor contract was deployed to mainnet on July 31st, 2023
       // using DeployScript in this repo.
       governorBravo = GitcoinGovernor(payable(DEPLOYED_BRAVO_GOVERNOR));
     } else {
@@ -118,7 +118,7 @@ abstract contract ProposalTestHelper is GitcoinGovernorTestHelper {
     GitcoinGovernorTestHelper.setUp();
 
     if (_useDeployedGovernorBravo()) {
-      // The actual upgrade proposal submitted to Governor Alpha by kbw.eth on 8/9/2023
+      // The actual upgrade proposal submitted to Governor Alpha by kbw.eth on August 9th, 2023
       upgradeProposalId = 65;
       // Since the proposal was already submitted, the count before its submissions is one less
       initialProposalCount = governorAlpha.proposalCount() - 1;
@@ -1370,7 +1370,7 @@ abstract contract FlexVotingTest is GovernorBravoProposalHelper {
   }
 }
 
-// Exercise the existing Bravo contract deployed on April 7th 2023.
+// Exercise the existing Bravo contract deployed on July 31st, 2023.
 contract BravoGovernorDeployTestWithExistingBravo is BravoGovernorDeployTest {
   function _useDeployedGovernorBravo() internal pure override returns (bool) {
     return true;

--- a/test/TestableProposeScript.sol
+++ b/test/TestableProposeScript.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.17;
+
+import {ProposeScript} from "script/Propose.s.sol";
+
+/// @dev An extension of the proposal script for use in tests
+contract TestableProposeScript is ProposeScript {
+  /// @dev Used only in the context of testing in order to allow an alternate address to be the
+  /// proposer. This is needed when testing with live proposal data, because the Governor only
+  /// allows each proposer to have one live proposal at a time.
+  function overrideProposerForTests(address _testProposer) external {
+    PROPOSER = _testProposer;
+  }
+}


### PR DESCRIPTION
Note: the linter is currently failing because I added [this](https://github.com/gitcoinco/Alpha-Governor-Upgrade/pull/27/files#diff-cf48972d889b83b06f8c72adceb844c329d215c51775ba9953f091077b832733R39) public method to override the proposer during tests to the Propose script.